### PR TITLE
Fix casing of imports

### DIFF
--- a/checkpoints_test.go
+++ b/checkpoints_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/twitchscience/kinsumer/mocks"
+	"github.com/TwitchScience/kinsumer/mocks"
 )
 
 func TestCheckpointer(t *testing.T) {

--- a/cmd/noopkinsumer/main.go
+++ b/cmd/noopkinsumer/main.go
@@ -12,11 +12,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/TwitchScience/kinsumer"
+	"github.com/TwitchScience/kinsumer/statsd"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/twinj/uuid"
-	"github.com/twitchscience/kinsumer"
-	"github.com/twitchscience/kinsumer/statsd"
 )
 
 var (


### PR DESCRIPTION
These probably were working on OSX because OSX's file system is case insensitive, but on linux with ext4 these break.
