### PR TITLE
Do not error if we do not expect to get assigned any shards

### DIFF
--- a/kinsumer.go
+++ b/kinsumer.go
@@ -184,6 +184,10 @@ func (k *Kinsumer) startConsumers() error {
 	k.stop = make(chan struct{})
 	assigned := false
 
+	if k.thisClient >= len(k.shardIDs) {
+		return nil
+	}
+
 	for i, shard := range k.shardIDs {
 		if (i % k.totalClients) == k.thisClient {
 			k.waitGroup.Add(1)


### PR DESCRIPTION
This is how I tested

- Ran my service with more machines than needed.
- Verified with debug text that this case was triggered
- Shut down the other clients
- Waited for the timeout and started consuming 