### PR TITLE
Allow starting from LATEST position

### DIFF
--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -36,6 +36,9 @@ func getShardIterator(k kinesisiface.KinesisAPI, streamName string, shardID stri
 	if sequenceNumber == "" {
 		shardIteratorType = kinesis.ShardIteratorTypeTrimHorizon
 		ps = nil
+	} else if sequenceNumber == "LATEST" {
+		shardIteratorType = kinesis.ShardIteratorTypeLatest
+		ps = nil
 	}
 
 	resp, err := k.GetShardIterator(&kinesis.GetShardIteratorInput{


### PR DESCRIPTION
This implements support for `ShardIteratorTypeLatest`. By setting `SequenceNumber` in DynamoDB to `LATEST`, consumers can start with the latest records in the stream.