### PR TITLE
Fix data race around leader handling

### DIFF
--- a/kinsumer.go
+++ b/kinsumer.go
@@ -357,11 +357,7 @@ func (k *Kinsumer) Run() error {
 			if err != nil {
 				k.errors <- fmt.Errorf("error deregistering client: %s", err)
 			}
-			if k.isLeader {
-				close(k.leaderLost)
-				k.leaderLost = nil
-				k.isLeader = false
-			}
+			k.unbecomeLeader()
 			// Do this outside the k.isLeader check in case k.isLeader was false because
 			// we lost leadership but haven't had time to shutdown the goroutine yet.
 			k.leaderWG.Wait()


### PR DESCRIPTION
This is a fix for #19, but I'm not 100% sure if the leadership behaviour is correct because the integration tests don't work, neither on master nor with this commit. I've tried `go test ./...` with kinesalite & dynalite, but the tests never finish and Go kills it at the 10 minute mark.