### PR TITLE
Fetch shard IDs from Kinesis if DynamoDB cache is empty

### DIFF
--- a/kinsumer.go
+++ b/kinsumer.go
@@ -58,7 +58,6 @@ type Kinsumer struct {
 	isLeader              bool                      // Whether this client is the leader
 	leaderLost            chan bool                 // Channel that receives an event when the node loses leadership
 	leaderWG              sync.WaitGroup            // waitGroup for the leader loop
-	firstRun              int32                     // Used to skip dynamodb shard cache on first start
 	maxAgeForClientRecord time.Duration             // Cutoff for client/checkpoint records we read from dynamodb before we assume the record is stale
 	maxAgeForLeaderRecord time.Duration             // Cutoff for leader/shard cache records we read from dynamodb before we assume the record is stale
 }
@@ -157,15 +156,19 @@ func (k *Kinsumer) refreshShards() (bool, error) {
 		k.unbecomeLeader()
 	}
 
-	firstRun := atomic.CompareAndSwapInt32(&k.firstRun, 1, 0)
-	if firstRun {
+	shardIDs, err = loadShardIDsFromDynamo(k.dynamodb, k.metadataTableName)
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(shardIDs) == 0 {
 		shardIDs, err = loadShardIDsFromKinesis(k.kinesis, k.streamName)
 		if err == nil {
 			err = k.setCachedShardIDs(shardIDs)
 		}
-	} else {
-		shardIDs, err = loadShardIDsFromDynamo(k.dynamodb, k.metadataTableName)
 	}
+
 	if err != nil {
 		return false, err
 	}
@@ -258,20 +261,6 @@ func (k *Kinsumer) dynamoTableExists(name string) bool {
 func (k *Kinsumer) dynamoCreateTableIfNotExists(name, distKey string) error {
 	if k.dynamoTableExists(name) {
 		return nil
-	}
-
-	if name == k.metadataTableName {
-		// If the metadata table is being created for the first time
-		// the loadShardIDsFromDynamo() call in refreshShards() will
-		// always return an empty shard list.
-		//
-		// This would cause the consumer to wait until the next leader
-		// election to start receiving events, because that's the only
-		// time loadShardIDsFromKinesis() is called.
-		//
-		// To fix this, we mark this run as "first run", which can be
-		// used by refreshShards() to skip the cache.
-		atomic.StoreInt32(&k.firstRun, 1)
 	}
 
 	_, err := k.dynamodb.CreateTable(&dynamodb.CreateTableInput{


### PR DESCRIPTION
On startup, if the metadata table is being created for the
first time, `loadShardIDsFromDynamo()` call in `refreshShards()`
will always return an empty shard list.

This causes the consumer to wait until the next leader
election to start receiving events, because that's the only
time `loadShardIDsFromKinesis()` is called. By default, this happens
once a minute, which means the consumer basically sleeps for 1
minute on first run.

This commit fixes that by adding a first run flag and skipping the
cache if it's true.

Fixes #17.