### PR TITLE
Allow UPDATING stream status

### DIFF
--- a/kinsumer.go
+++ b/kinsumer.go
@@ -323,8 +323,8 @@ func (k *Kinsumer) kinesisStreamReady() error {
 	}
 
 	status := aws.StringValue(out.StreamDescription.StreamStatus)
-	if status != "ACTIVE" {
-		return fmt.Errorf("stream %s exists but state '%s' is not 'ACTIVE'", k.streamName, status)
+	if status != "ACTIVE" && status != "UPDATING" {
+		return fmt.Errorf("stream %s exists but state '%s' is not 'ACTIVE' or 'UPDATING'", k.streamName, status)
 	}
 
 	return nil


### PR DESCRIPTION
Per https://docs.aws.amazon.com/kinesis/latest/APIReference/API_StreamDescription.html
a stream is valid for reading and writing while in the UPDATING status.
We encountered this while scaling a stream.