### PR TITLE
Add Manual Checkpointing

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,8 +11,9 @@ import (
 
 // Config holds all configuration values for a single Kinsumer instance
 type Config struct {
-	stats  StatReceiver
-	logger Logger
+	stats               StatReceiver
+	logger              Logger
+	manualCheckpointing bool
 
 	// ---------- [ Per Shard Worker ] ----------
 	// Time to sleep if no records are found
@@ -57,6 +58,15 @@ func NewConfig() Config {
 		dynamoWaiterDelay:     3 * time.Second,
 		logger:                &DefaultLogger{},
 	}
+}
+
+// WithManualCheckpointing returns a Config with a modified manual checkpointing flag
+// If set to false, records will be automatically checkpointed upon calls to Next()
+// If set to true, NextWithCheckpointer() must be used and the returned checkpointer function
+// must be called when the record is fully processed.
+func (c Config) WithManualCheckpointing(v bool) Config {
+	c.manualCheckpointing = v
+	return c
 }
 
 // WithThrottleDelay returns a Config with a modified throttle delay

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -412,7 +412,9 @@ func (k *Kinsumer) Run() error {
 				return
 			case record = <-input:
 			case output <- record:
-				record.checkpointer.update(aws.StringValue(record.record.SequenceNumber))
+				if !k.config.manualCheckpointing {
+					record.checkpointer.update(aws.StringValue(record.record.SequenceNumber))
+				}
 				record = nil
 			case se := <-k.shardErrors:
 				k.errors <- fmt.Errorf("shard error (%s) in %s: %s", se.shardID, se.action, se.err)
@@ -451,6 +453,10 @@ func (k *Kinsumer) Stop() {
 // if err is non nil an error occurred in the system.
 // if err is nil and data is nil then kinsumer has been stopped
 func (k *Kinsumer) Next() (data []byte, err error) {
+	if k.config.manualCheckpointing {
+		return nil, fmt.Errorf("manual checkpointing is enabled, use NextWithCheckpointer() instead")
+	}
+
 	select {
 	case err = <-k.errors:
 		return nil, err
@@ -462,6 +468,32 @@ func (k *Kinsumer) Next() (data []byte, err error) {
 	}
 
 	return data, err
+}
+
+// NextWithCheckpointer is a blocking function used to get the next record from the kinesis queue, or errors that
+// occurred during the processing of kinesis. It's up to the caller to stop processing by calling 'Stop()'
+// checkpointer should be called when the record is fully processed. Kinsumer will ensure checkpointer calls are ordered.
+// WARNING: checkpointer() can block indefinitely if not called in order.
+//
+// if err is non nil an error occurred in the system.
+// if err is nil and data is nil then kinsumer has been stopped
+func (k *Kinsumer) NextWithCheckpointer() (data []byte, checkpointer func(), err error) {
+	select {
+	case err = <-k.errors:
+		return nil, nil, err
+	case record, ok := <-k.output:
+		if ok {
+			k.config.stats.EventToClient(*record.record.ApproximateArrivalTimestamp, record.retrievedAt)
+			data = record.record.Data
+			if k.config.manualCheckpointing {
+				checkpointer = record.checkpointer.updateFunc(aws.StringValue(record.record.SequenceNumber))
+			} else {
+				checkpointer = func() { /* no-op since automatic checkpointing is enabled */ }
+			}
+		}
+	}
+
+	return data, checkpointer, err
 }
 
 // CreateRequiredTables will create the required dynamodb tables


### PR DESCRIPTION
This adds a new config option, `WithManualCheckpointing(true)`, that disables the automatic checkpoint on `Next()` and adds a new method `NextWithCheckpointer()` that includes a new return argument, `func()`, which updates the checkpoint when called. This feature allows users to delay checkpointing until a record is fully processed to ensure records are never dropped.

I've also included some additional complexity in that Kinsumer (rather than the user) ensures checkpoints are done in-order. This is done to prevent race-conditions, but could result in confusing behavior for users where calling the checkpointer could lead to indefinite blocking and checkpoints never being updated.

Good Example:
```go
for {
  record, checkpointer, _ := k.NextWithCheckpointer()
  go func() {
    process(record)
    checkpointer() // may block for a while but will eventually complete
  }()
}
```

In this example every checkpointer is called, and called in a way that doesn't block processing other records, which ensures that eventually they will update the checkpoint and return. Because processing is done asynchronously it is possible a later record finishes before an earlier record and has to wait, but eventually they should all complete.

```go
for {
  record, checkpointer, _ := k.NextWithCheckpointer()
  process(record)
  checkpointer() // should never block
}
```

This is also fine since serially calling checkpointers ensures they are called in order, which should never block.

Bad Examples:
```go
var records [][]byte
var lastCheckpointer func()
for i := 0; i < 10; i++ {
  record, checkpointer, _ := k.NextWithCheckpointer()
  records = append(records, record)
  lastCheckpointer = checkpointer
}
process(records)
lastCheckpointer() // blocks forever, never actually updates the checkpoint
```
In this example the user thought they only needed to call the last checkpointer, since sequence numbers are always increasing the last value should encompass all prior values. This is not true, each checkpointer must be called, both to ensure ordering and since records may belong to different shards. This can be fixed by storing all checkpointers in a slice and calling them in order.

```go
batches := map[string]batch{}
for {
  record, checkpointer, _ := k.NextWithCheckpointer()
  id := customerIDFromRecord(record)
  b := batches[id]
  b.Records = append(b.Records, record)
  b.Checkpointers = append(b.Checkpointers, checkpointer)
  if len(b.Records) >= 100 {
    process(b.Records)
    for _, checkpointer := range b.Checkpointers {
      checkpointer()
    }
    b = batch{}
  }
  batches[id] = b
}
```

At first glance this looks fairly reasonable: all checkpointers are being called and order is maintained. However because the user is splitting by customerID it is possible for `checkpointer()` to block forever waiting on a `checkpointer` for a different customerID, which can now never happen because we are blocking the processing loop. This can be fixed by using `go checkpointer()`, but logic should also be added to flush batches after a period of time to ensure checkpoints don't fall surprisingly far behind.