### PR TITLE
add ResetCheckpoints function

### DIFF
--- a/kinsumer.go
+++ b/kinsumer.go
@@ -505,7 +505,7 @@ func (k *Kinsumer) ResetCheckpoints() error {
 }
 
 func (k *Kinsumer) resetCheckpointPageFactory(errChan chan<- error) func(*dynamodb.ScanOutput, bool) bool {
-	resetCheckpointPage := func(entries *dynamodb.ScanOutput, lastPage bool) bool {
+	return func(entries *dynamodb.ScanOutput, lastPage bool) bool {
 		for _, entry := range entries.Items {
 			shard := entry["Shard"].S
 
@@ -526,9 +526,8 @@ func (k *Kinsumer) resetCheckpointPageFactory(errChan chan<- error) func(*dynamo
 		}
 		return true
 	}
-
-	return resetCheckpointPage
 }
+
 func (k *Kinsumer) updateItem(id string) error {
 	condition := expression.Name("Shard").Equal(expression.Value(id))
 	var update = expression.UpdateBuilder{}

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -510,7 +510,7 @@ func (k *Kinsumer) resetCheckpointPageFactory(errChan chan<- error) func(*dynamo
 			shard := entry["Shard"].S
 
 			if shard == nil {
-				errChan <- fmt.Errorf("found %v for Shard entry", entry["Shard"].S)
+				errChan <- fmt.Errorf("found %s for Shard entry", *entry["Shard"].S)
 				return false
 			}
 

--- a/kinsumer.go
+++ b/kinsumer.go
@@ -174,9 +174,9 @@ func (k *Kinsumer) refreshShards() (bool, error) {
 		return false, err
 	}
 
-	changed := totalClients != k.totalClients ||
-		thisClient != k.thisClient ||
-		len(k.shardIDs) != len(shardIDs)
+	changed := (totalClients != k.totalClients) ||
+		(thisClient != k.thisClient) ||
+		(len(k.shardIDs) != len(shardIDs))
 
 	if !changed {
 		for idx := range shardIDs {
@@ -208,7 +208,7 @@ func (k *Kinsumer) startConsumers() error {
 	}
 
 	for i, shard := range k.shardIDs {
-		if i%k.totalClients == k.thisClient {
+		if (i % k.totalClients) == k.thisClient {
 			k.waitGroup.Add(1)
 			assigned = true
 			go k.consume(shard)


### PR DESCRIPTION
Adds a `ResetCheckpoints` function which sets all existing dynamo checkpoints to `LATEST`. 

This is useful to call as part of a deploy if you want to make sure that all new readers start at the most recent record instead of picking up where the the old readers left off.