### PR TITLE
Improve aws error rendering

### DIFF
--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -3,6 +3,7 @@
 package kinsumer
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -188,7 +189,11 @@ mainloop:
 
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
-				k.config.logger.Log("Got error: %s %s (%s) retry count is %d / %d", awsErr.Code(), awsErr.Message(), awsErr.OrigErr(), retryCount, maxErrorRetries)
+				origErrStr := ""
+				if awsErr.OrigErr() != nil {
+					origErrStr = fmt.Sprintf("(%s) ", awsErr.OrigErr())
+				}
+				k.config.logger.Log("Got error: %s %s %sretry count is %d / %d", awsErr.Code(), awsErr.Message(), origErrStr, retryCount, maxErrorRetries)
 				if retryCount < maxErrorRetries {
 					retryCount++
 

--- a/shard_consumer.go
+++ b/shard_consumer.go
@@ -188,7 +188,7 @@ mainloop:
 
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
-				k.config.logger.Log("Got error: %s (%s) retry count is %d / %d", awsErr.Message(), awsErr.OrigErr(), retryCount, maxErrorRetries)
+				k.config.logger.Log("Got error: %s %s (%s) retry count is %d / %d", awsErr.Code(), awsErr.Message(), awsErr.OrigErr(), retryCount, maxErrorRetries)
 				if retryCount < maxErrorRetries {
 					retryCount++
 


### PR DESCRIPTION
Currently we see errors logged like:

```
Got error:  (%!s(<nil>)) retry count is 0 / 3
```

Which implies there are cases where `awsErr.Message() == ""`. For that reason I think it's more important that the `awsErr.Code()` is logged.

In addition, the formatting looks quite ugly when  `awsErr.Message() == nil`, so I also added a conditional check before formatting it.