### PR TITLE
Add configuration option to start from timestamp

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,10 @@ type Config struct {
 
 	// Delay between tests for the client or shard numbers changing
 	shardCheckFrequency time.Duration
+
+	// Starting timestamp of the shard iterator, if "AT_TIMESTAMP" is the desired iterator type
+	iteratorStartTimestamp *time.Time
+
 	// ---------- [ For the leader (first client alphabetically) ] ----------
 	// Time between leader actions
 	leaderActionFrequency time.Duration
@@ -92,6 +96,12 @@ func (c Config) WithBufferSize(bufferSize int) Config {
 // WithStats returns a Config with a modified stats
 func (c Config) WithStats(stats StatReceiver) Config {
 	c.stats = stats
+	return c
+}
+
+// WithIteratorStartTimestamp returns a Config with a modified iteratorStartTimestamp
+func (c Config) WithIteratorStartTimestamp(timestamp *time.Time) Config {
+	c.iteratorStartTimestamp = timestamp
 	return c
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -13,6 +13,7 @@ func TestConfigDefault(t *testing.T) {
 	config := NewConfig()
 	err := validateConfig(&config)
 	require.NoError(t, err)
+	require.Nil(t, config.iteratorStartTimestamp)
 }
 
 func TestConfigErrors(t *testing.T) {
@@ -55,13 +56,15 @@ func TestConfigErrors(t *testing.T) {
 
 func TestConfigWithMethods(t *testing.T) {
 	stats := &NoopStatReceiver{}
+	tstamp := time.Now()
 	config := NewConfig().
 		WithBufferSize(1).
 		WithCommitFrequency(1 * time.Second).
 		WithShardCheckFrequency(1 * time.Second).
 		WithLeaderActionFrequency(1 * time.Second).
 		WithThrottleDelay(1 * time.Second).
-		WithStats(stats)
+		WithStats(stats).
+		WithIteratorStartTimestamp(&tstamp)
 
 	err := validateConfig(&config)
 	require.NoError(t, err)
@@ -72,4 +75,5 @@ func TestConfigWithMethods(t *testing.T) {
 	require.Equal(t, 1*time.Second, config.shardCheckFrequency)
 	require.Equal(t, 1*time.Second, config.leaderActionFrequency)
 	require.Equal(t, stats, config.stats)
+	require.Equal(t, &tstamp, config.iteratorStartTimestamp)
 }


### PR DESCRIPTION
This PR adds a start timestamp to configuration, allowing kinsumer's iterator to use `AT_TIMESTAMP` to define the initial position in the stream.